### PR TITLE
Correct a bug with the diskname

### DIFF
--- a/install/create-lxc
+++ b/install/create-lxc
@@ -30,9 +30,9 @@ for CMD in $COMMANDS; do
 	lxc-start -n $NAME -f $NAME.install.config
 	sleep 5s
 	lxc-attach -n $NAME -- /opt/setup/$CMD
-	lxc-stop -n ashlan
+	lxc-stop -n $NAME
 done
-lxc-start -n ashlan
+lxc-start -n $NAME
 sleep 5s
 lxc-attach -n $NAME -- docker run -d -p 5000:5000 --restart=always --name registry -v /var/lib/docker-registry/data:/var/lib/registry -v /var/lib/docker-registry/certs:/certs -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key registry:2
 rm -f ./$NAME.install.config

--- a/onedock.sh
+++ b/onedock.sh
@@ -36,8 +36,6 @@ function setup_frontend {
         LIB_LOCATION=$ONE_LOCATION/lib
     fi
     
-    . $LIB_LOCATION/sh/scripts_common.sh
-    
     source ${DRIVER_PATH}/../../datastore/libfs.sh
     export LIB_LOCATION
     export XPATH_APP="${DRIVER_PATH}/../../datastore/xpath.rb"

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -34,6 +34,7 @@ VMID="${XPATH_ELEMENTS[i++]}"
 NAME="${XPATH_ELEMENTS[i++]}"
 IMAGEID="${XPATH_ELEMENTS[i++]}"
 DN=$(readlink -e ${DRIVER_PATH}/../../docker-manage-network)
+DISKIMAGENAME=$(build_dock_name "$LOCAL_SERVER" "" "one-$VMID" "0")
 
 CREATEDEPFILE=yes
 EXISTS=$(docker inspect -f '{{.State.Running}}' "$NAME" 2>/dev/null)
@@ -55,7 +56,7 @@ EOF
     else
 	DOCKERRUNCMD=
     fi
-    data=`docker run --net="none" -td --name $NAME $LOCAL_SERVER/$IMAGE_BASENAME:$IMAGEID $DOCKERRUNCMD 2>&1`
+    data=`docker run --net="none" -td --name $NAME $DISKIMAGENAME $DOCKERRUNCMD 2>&1`
 fi
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Corrects a bug with the name used for the disk 0 at the moment of deploying a VM.

Also had another bug regarding the "sed" command in ONE because of how the SED var is defined.
