### PR TITLE
Add volume support to ONEdock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ EOT
 You need to update the file ```/etc/sudoers.d/opennebula``` to add the file that will configure the network. You need to add the line
 
 ```bash
-Cmnd_Alias ONEDOCK = /var/tmp/one/docker-manage-network, /usr/bin/qemu-nbd
+Cmnd_Alias ONEDOCK = /var/tmp/one/docker-manage-network, /usr/bin/qemu-nbd, /usr/bin/vncterm, /bin/systemctl
 ```
 
 And to activate this alias appending the alias in the following line

--- a/docker-manage-network
+++ b/docker-manage-network
@@ -69,12 +69,12 @@ function setup_bridge {
     # 
     # @Syntax: setup_bridge $1
     #
-    # This function creates a bridge with the name in parameter $1, using brctl, and sets it up using ip command
+    # This function creates a bridge with the name in parameter $1, using ovs-vsctl, and sets it up using ip command
     #
     BRNAME=$1
-    CHECKSTR=$(brctl show | grep "$BRNAME")
+    CHECKSTR=$(sudo ovs-vsctl list-br | grep "$BRNAME")
     if [ "$CHECKSTR" == "" ]; then
-        brctl addbr "$BRNAME"
+        sudo ovs-vsctl add-br "$BRNAME"
         
         if [ $? -ne 0 ]; then
             finalize "could not create bridge $BRNAME"
@@ -94,7 +94,7 @@ function check_bridge {
     # Checks whether bridge $1 exists or not
     #
     BRNAME=$1
-    CHECKSTR=$(brctl show | grep "$BRNAME")
+    CHECKSTR=$(sudo ovs-vsctl list-br | grep "$BRNAME")
     if [ "$CHECKSTR" == "" ]; then
         return 1
     else
@@ -114,7 +114,7 @@ function build_ns {
     PID=$(docker inspect -f '{{.State.Pid}}' $DOCKID)
     
     if [ $? -ne 0 ] || [ $PID -eq 0 ]; then
-	echo "could not find container $DOCKID"
+        echo "could not find container $DOCKID"
         finalize "could not find container $DOCKID"
     fi
     
@@ -154,7 +154,8 @@ function create_device {
     VETH1=v${DEVNAME}${NSDOCK}-1
     ip link add $VETH0 type veth peer name $VETH1
     ip link set $VETH1 netns $NSDOCK
-    brctl addif $BRNAME $VETH0
+    #ovs-docker add-port $BRNAME $VETH0 $CONTAINERNAME
+    ovs-vsctl add-port $BRNAME $VETH0
     ip link set dev $VETH0 up
     ip netns exec $NSDOCK ip link set dev $VETH1 name $DEVNAME
     ip netns exec $NSDOCK ip link set dev $DEVNAME up
@@ -174,6 +175,7 @@ function delete_device {
     NSDOCK=$(build_ns $DOCKID)
     set -e
     ip netns exec $NSDOCK ip link delete dev $DEVNAME
+    ovs-vsctl del-port $DEVNAME
     set +e
     log_debug "device $DEVNAME deleted from container $DOCKID"
 }
@@ -352,17 +354,17 @@ while [ $# -gt 0 ]; do
                             OP=$[ $OP + 1 ];;
     --get-info|-g)          INFO=True
                             OP=$[ $OP + 1 ];;
-    --create-device|-c)	    read_param DEVICENAME $@
+    --create-device|-c)     read_param DEVICENAME $@
                             exit_on_error "missing parameter for --create-device"
                             CREATE=True
                             OP=$[ $OP + 1 ]
                             shift;;
-    --update-device|-u)	    read_param DEVICENAME $@
+    --update-device|-u)     read_param DEVICENAME $@
                             exit_on_error "missing parameter for --update-device"
                             UPDATE=True
                             OP=$[ $OP + 1 ]
                             shift;;
-    --delete-device|-d)	    read_param DEVICENAME $@
+    --delete-device|-d)     read_param DEVICENAME $@
                             exit_on_error "missing parameter for --delete-device"
                             DELETE=True
                             OP=$[ $OP + 1 ]

--- a/tm/onedock/clone
+++ b/tm/onedock/clone
@@ -45,12 +45,16 @@ DST_DIR=`dirname $DST_PATH`
 DISKIMAGENAME=$(build_dock_name "$LOCAL_SERVER" "" "one-$VMID" "$DISK_ID")
 
 DOCKERRUN=
+DOCKERVOL=
 PROTOCOL=${SRC::9}
 if [ "$PROTOCOL" == "docker://" ]; then
     read_xpath "$(onevm show -x $VMID)" "/VM/TEMPLATE/DISK[DISK_ID=$DISK_ID]/IMAGE_ID"
     IMGID=${XPATH_ELEMENTS[0]}
     read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERRUN"
     DOCKERRUN=${XPATH_ELEMENTS[0]}
+    read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERVOL"
+    DOCKERVOL=${XPATH_ELEMENTS[0]}
+
 
     DOCKER_IMG_NAME=${SRC:9}
     DOCKER_CMD="docker pull ${DOCKER_IMG_NAME}"
@@ -78,6 +82,11 @@ if [ "$DOCKERRUN" != "" ]; then
     ssh_make_path $DST_HOST $DST_DIR
     ssh_exec_and_log $DST_HOST "echo '$DOCKERRUN' > ${DST_PATH}.dockerrun"
 fi
+if [ "$DOCKERVOL" != "" ]; then
+    ssh_make_path $DST_HOST $DST_DIR
+    ssh_exec_and_log $DST_HOST "echo '$DOCKERVOL' > ${DST_PATH}.dockervol"
+fi
+
 log_onedock_debug "image $DOCKER_IMG_NAME tagged as $DISKIMAGENAME"
 DOCKER_CMD="docker rmi $DOCKER_IMG_NAME"
 ssh_exec_and_log "$DST_HOST" "$DOCKER_CMD" "Error removing image $DOCKER_IMG_NAME"

--- a/tm/onedock/clone
+++ b/tm/onedock/clone
@@ -52,6 +52,7 @@ if [ "$PROTOCOL" == "docker://" ]; then
     IMGID=${XPATH_ELEMENTS[0]}
     read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERRUN"
     DOCKERRUN=${XPATH_ELEMENTS[0]}
+    DOCKERRUN_B64=$(base64 <<< $DOCKERRUN
     read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERVOL"
     DOCKERVOL=${XPATH_ELEMENTS[0]}
 
@@ -80,7 +81,7 @@ DOCKER_CMD="docker tag -f $DOCKER_IMG_NAME $DISKIMAGENAME"
 ssh_exec_and_log "$DST_HOST" "$DOCKER_CMD" "Error tagging the image $DOCKER_IMG_NAME as $DISKIMAGENAME"
 if [ "$DOCKERRUN" != "" ]; then
     ssh_make_path $DST_HOST $DST_DIR
-    ssh_exec_and_log $DST_HOST "echo '$DOCKERRUN' > ${DST_PATH}.dockerrun"
+    ssh_exec_and_log $DST_HOST "echo "$DOCKERRUN_B64" | base64 -d > ${DST_PATH}.dockerrun"
 fi
 if [ "$DOCKERVOL" != "" ]; then
     ssh_make_path $DST_HOST $DST_DIR

--- a/tm/onedock/clone
+++ b/tm/onedock/clone
@@ -52,7 +52,7 @@ if [ "$PROTOCOL" == "docker://" ]; then
     IMGID=${XPATH_ELEMENTS[0]}
     read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERRUN"
     DOCKERRUN=${XPATH_ELEMENTS[0]}
-    DOCKERRUN_B64=$(base64 <<< $DOCKERRUN
+    DOCKERRUN_B64=$(base64 <<< $DOCKERRUN)
     read_xpath "$(oneimage show -x $IMGID)" "/IMAGE/TEMPLATE/DOCKERVOL"
     DOCKERVOL=${XPATH_ELEMENTS[0]}
 

--- a/vmm/onedock/cancel
+++ b/vmm/onedock/cancel
@@ -41,6 +41,12 @@ fi
 log_onedock_debug $(docker stop "$NAME" && docker rm "$NAME")
 ERR=$?
 
+log_onedock_debug $(sudo systemctl stop vncterm-"$NAME".service)
+ERR=$?
+
+log_onedock_debug $(sudo systemctl disable vncterm-"$NAME".service)
+ERR=$?
+
 # This is just to clean possible snapshots (maybe there are none)
 DISKIMAGENAME=$(build_dock_name "$LOCAL_SERVER" "" "$NAME" "0")
 docker rmi "$DISKIMAGENAME" > /dev/null 2> /dev/null

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -77,7 +77,7 @@ fi
         
 # docker run --net="none" --device /dev/nbd0:/dev/hdc --device /dev/nbd0p1:/dev/hdc1 --cap-add SYS_ADMIN --security-opt apparmor:unconfined -td --name one-3 onedockvol:5000/one-3:0 
 log_onedock_debug "docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DOCKERVOLCMD $DISKIMAGENAME $DOCKERRUNCMD 2>&1"
-data=`docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DOCKERVOLCMD $DISKIMAGENAME $DOCKERRUNCMD 2>&1`
+data=$(sh -c "docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DOCKERVOLCMD $DISKIMAGENAME $DOCKERRUNCMD 2>&1")
 
 if [ $? -eq 0 ]; then
     echo $CONTAINERNAME

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -66,10 +66,18 @@ elif [ "$ONEDOCK_DEFAULT_DOCKERRUN" != "" ]; then
 else
     DOCKERRUNCMD=
 fi
+
+ONEDOCK_DOCKERVOL=$DATASTOREFOLDER/disk.0.dockervol
+if [ -e "$ONEDOCK_DOCKERVOL" ]; then
+    DOCKERVOLCMD="$(cat $ONEDOCK_DOCKERVOL)"
+else
+    DOCKERVOLCMD=
+fi
+
         
 # docker run --net="none" --device /dev/nbd0:/dev/hdc --device /dev/nbd0p1:/dev/hdc1 --cap-add SYS_ADMIN --security-opt apparmor:unconfined -td --name one-3 onedockvol:5000/one-3:0 
-log_onedock_debug "docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DISKIMAGENAME $DOCKERRUNCMD 2>&1"
-data=`docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DISKIMAGENAME $DOCKERRUNCMD 2>&1`
+log_onedock_debug "docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DOCKERVOLCMD $DISKIMAGENAME $DOCKERRUNCMD 2>&1"
+data=`docker run $NETWORK_STR $DEVICES_STR -td --name $CONTAINERNAME $DOCKERVOLCMD $DISKIMAGENAME $DOCKERRUNCMD 2>&1`
 
 if [ $? -eq 0 ]; then
     echo $CONTAINERNAME

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -92,6 +92,14 @@ if [ $? -eq 0 ]; then
         error_message "network contextualization failed: $(echo $NETCONTEXT | tr -d '\n')"
         exit 1
     fi
+
+#setup vncterm
+CONTAINERID="$(docker ps -a -q --filter=name=$CONTAINERNAME)"
+VNC_STR=$(setup_vncterm "$DOMXML" "$CONTAINERNAME" "$CONTAINERID")
+if [ $? -ne 0 ]; then
+    error_message "could not setup vncterm for deployment $domain"
+    exit 1
+fi
     exit 0
 else
     error_message "Could not create domain from $domain: $data"

--- a/vmm/onedock/vmmfnc.sh
+++ b/vmm/onedock/vmmfnc.sh
@@ -42,7 +42,7 @@ function setup_disk {
     
     log_onedock_debug "connecting disk $2 in $NBD_TGT"
     log_onedock_debug "qemu-nbd -c \"$NBD_TGT\" \"${FOLDER}/disk.${DISK_ID}\""
-    sudo /usr/bin/qemu-nbd -c $NBD_TGT "${FOLDER}/disk.${DISK_ID}" 2> /dev/null
+    sudo /usr/bin/qemu-nbd -c $NBD_TGT "${FOLDER}/disk.${DISK_ID}" "--format=raw" 2> /dev/null
     if [ $? -ne 0 ]; then
         log_onedock_debug "FAILED: connecting disk $2 in $NBD_TGT"    
         echo "could not connect the disk $DISK_ID"


### PR DESCRIPTION
To be able to add "volumes" to docker containers the following could be added in a image template specification to share the host volume "/var/lib/one/datastores/persistent-storage" to the container in "/mnt" for example

DOCKERVOL="-v /var/lib/one/datastores/persistent-storage:/mnt"

If this volume is a nfs share shared by the hosts than all containers sharing this volume can access the same storage
