### PR TITLE
configurable deletion of the images in the internal nodes

### DIFF
--- a/onedock.conf
+++ b/onedock.conf
@@ -15,11 +15,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# This is the URL for the registry
 export LOCAL_SERVER=dockerregistry:5000
 export LOCAL_SERVER=onedock-tests:5000
+
+# ONEDock removes the images from the internal nodes when the containers are finalized. This is made in order to save storage.
+#   * Setting this variable to a value different to "yes" prevents from removing these images
+export DELETE_LOCAL_IMAGES=yes
+
+# This is the path in which the docker registry will store the docker images in the front-end
 export DATASTORE_DATA_PATH=/var/lib/docker-registry/data/
+
+# This is the path for the onedock log file
 export ONEDOCK_LOGFILE=/var/log/onedock.log
+
+# The images in the registry are stored as <IMAGE_BASENAME>:<id in ONE>
 export IMAGE_BASENAME=dockerimage
+
+# Setting ONEDOCK_DEBUG to "True" sets onedock in "debug" mode and will output a lot of information
 export ONEDOCK_DEBUG=True
+
+# These are the default values for the network in the containers
 export ONEDOCK_DEFAULT_NETMASK=24
 export ONEDOCK_DEFAULT_DHCP=yes

--- a/tm/onedock/clone
+++ b/tm/onedock/clone
@@ -88,7 +88,9 @@ log_onedock_debug "image $DOCKER_IMG_NAME tagged as $DISKIMAGENAME"
 if [ "$LOCAL_SERVER" == "" ]; then
         log_onedock_debug "WARNING: LOCAL_SERVER is not set: Assuming shared repository!!! (feature created for developers): not deleting the image"
 else
-    DOCKER_CMD="docker rmi $DOCKER_IMG_NAME"
-    ssh_exec_and_log "$DST_HOST" "$DOCKER_CMD" "Error removing image $DOCKER_IMG_NAME"
+    if [ "$DELETE_LOCAL_IMAGES" == "yes" ]; then
+        DOCKER_CMD="docker rmi $DOCKER_IMG_NAME"
+        ssh_exec_and_log "$DST_HOST" "$DOCKER_CMD" "Error removing image $DOCKER_IMG_NAME"
+    fi
 fi
 exit 0


### PR DESCRIPTION
In the original version, when a container was finalized in a host, the docker image used to create the proxy was removed from the host. This was made in order to save storage space. This version enables to configure this behaviour.

According to the ONE philosophy, the images created in the datastore will not change in the time (if you want a new version you should delete the old image and create a new one). So keeping the docker images in the virtualization nodes will greatly speed up the container creation.
