### PR TITLE
New CONTEXT CD

### DIFF
--- a/devel-env/startfrontend
+++ b/devel-env/startfrontend
@@ -17,6 +17,7 @@ docker run --name $CONTAINER -h $CONTAINER \
     -v $BASEDIR/etc_one:/etc/one \
     -v $PWD/..:/opt/onedock -id $IMAGENAME /bin/bash
 
-docker exec $CONTAINER groupmod -g $(cat /etc/group | grep docker | awk -F: '{print $3}') docker
+docker exec $CONTAINER groupmod \
+    -g $(cat /etc/group | grep docker | awk -F: '{print $3}') docker
 docker stop $CONTAINER
 docker start $CONTAINER

--- a/devel-env/startwn
+++ b/devel-env/startwn
@@ -24,6 +24,7 @@ docker exec $FRONTENDNAME bash -c "cat /etc/hosts | sed \"/$IP/d;/$WNNAME/d\" \
     > /tmp/hosts && echo \"$IP $WNNAME\" \
     >> /tmp/hosts && cp /tmp/hosts /etc/"
 
-docker exec $WNNAME groupmod -g $(cat /etc/group | grep docker | awk -F: '{print $3}') docker
+docker exec $WNNAME groupmod \
+    -g $(cat /etc/group | grep docker | awk -F: '{print $3}') docker
 docker stop $WNNAME
 docker start $WNNAME

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -29,7 +29,9 @@ done
 # Distribute the files in the hosts
 FOLDERS="datastore/onedock im/onedock-probes.d tm/onedock vmm/onedock"
 for F in $FOLDERS; do
-    for i in /var/lib/one/remotes/$F/*; do scpall $i /var/tmp/one/$F/; done
+    for i in /var/lib/one/remotes/$F/*; do
+        scpall $i /var/tmp/one/$F/
+    done
 done
 FILES="docker-manage-network onedock.sh onedock.conf"
 for F in $FILES; do

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# ONEDock - Docker support for ONE (as VMs)
+# Copyright (C) GRyCAP - I3M - UPV 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Copy the new files to the proper location
+FOLDERS="datastore/onedock im/onedock-probes.d tm/onedock vmm/onedock"
+for F in $FOLDERS; do
+    cp $F/* /var/lib/one/remotes/$F/; done
+done
+FILES="docker-manage-network onedock.sh onedock.conf"
+for F in $FILES; do
+    cp $F /var/lib/one/remotes/
+done
+
+# Distribute the files in the hosts
+FOLDERS="datastore/onedock im/onedock-probes.d tm/onedock vmm/onedock"
+for F in $FOLDERS; do
+    for i in /var/lib/one/remotes/$F/*; do scpall $i /var/tmp/one/$F/; done
+done
+FILES="docker-manage-network onedock.sh onedock.conf"
+for F in $FILES; do
+    scpall /var/lib/one/remotes/$F /var/tmp/one/$F
+done

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -19,7 +19,7 @@
 # Copy the new files to the proper location
 FOLDERS="datastore/onedock im/onedock-probes.d tm/onedock vmm/onedock"
 for F in $FOLDERS; do
-    cp $F/* /var/lib/one/remotes/$F/; done
+    cp $F/* /var/lib/one/remotes/$F/
 done
 FILES="docker-manage-network onedock.sh onedock.conf"
 for F in $FILES; do

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -66,7 +66,8 @@ if [ "$EXISTS" == "false" ] || [ "$EXISTS" == "true" ]; then
 fi
 
 DEVICES_STR=$(setup_devices "$DOMXML" "$DATASTOREFOLDER" \
-    "$ONEDOCK_DEVICES_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE")
+    "$ONEDOCK_DEVICES_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE" \
+    "$ONEDOCK_CONTAINER_FOLDER")
 if [ $? -ne 0 ]; then
     exec_file "$ONEDOCK_CLEANUP_FILE"
     error_message "could not setup devices for deployment $domain"
@@ -74,7 +75,8 @@ if [ $? -ne 0 ]; then
 fi
 
 CONTEXT_STR=$(setup_context "$DOMXML" "$DATASTOREFOLDER" \
-    "$ONEDOCK_CONTEXT_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE")
+    "$ONEDOCK_CONTEXT_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE" \
+    "$ONEDOCK_CONTAINER_FOLDER")
 if [ $? -ne 0 ]; then
     exec_file "$ONEDOCK_CLEANUP_FILE"
     error_message "could not setup context for deployment $domain"
@@ -100,7 +102,8 @@ if [ "$PRIV_STR" != "" -a "$ONEDOCK_PRIVILEGED" != "True" ]; then
 fi
 
 NETWORK_STR=$(setup_network "$DOMXML" "$DATASTOREFOLDER" \
-    "$ONEDOCK_NETWORK_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE")
+    "$ONEDOCK_NETWORK_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE" \
+    "$ONEDOCK_CONTAINER_FOLDER")    
 if [ $? -ne 0 ]; then
     exec_file "$ONEDOCK_CLEANUP_FILE"
     error_message "could not setup network for deployment $domain"

--- a/vmm/onedock/deploy
+++ b/vmm/onedock/deploy
@@ -41,9 +41,9 @@ NAME="${XPATH_ELEMENTS[i++]}"
 DN=$(readlink -e ${DRIVER_PATH}/../../docker-manage-network)
 
 if [ ! -e "$DN" ]; then
-    log_onedock_debug "docker-manage-network command does not exist. Please check that \
-    it is properly copied in the /var/lib/one/remotes folder and distributed in the\
-    hosts under the path /var/tmp/one"
+    log_onedock_debug "docker-manage-network command does not exist. Please \
+    check that it is properly copied in the /var/lib/one/remotes folder and \
+    distributed in the hosts under the path /var/tmp/one"
     exit -1
 fi
 
@@ -87,7 +87,8 @@ if [ "$DEVICES_STR" != "" -o "$CONTEXT_STR" != "" ]; then
     DEVICES_STR="$DEVICES_STR --cap-add SYS_ADMIN \
         --security-opt apparmor:unconfined"
 
-    if [ "$(echo "$DEVICES_STR$CONTEXT_STR" | grep -- '--privileged')" != "" ]; then
+    if [ "$(echo "$DEVICES_STR$CONTEXT_STR" | grep -- '--privileged')" \
+        != "" ]; then
         PRIV_STR="--privileged"
         DEVICES_STR=$(echo "$DEVICES_STR" | sed 's/--privileged//g')
         CONTEXT_STR=$(echo "$CONTEXT_STR" | sed 's/--privileged//g')
@@ -103,7 +104,7 @@ fi
 
 NETWORK_STR=$(setup_network "$DOMXML" "$DATASTOREFOLDER" \
     "$ONEDOCK_NETWORK_FILE" "$ONEDOCK_CLEANUP_FILE" "$ONEDOCK_BOOTSTRAP_FILE" \
-    "$ONEDOCK_CONTAINER_FOLDER")    
+    "$ONEDOCK_CONTAINER_FOLDER")
 if [ $? -ne 0 ]; then
     exec_file "$ONEDOCK_CLEANUP_FILE"
     error_message "could not setup network for deployment $domain"

--- a/vmm/onedock/vmmfnc.sh
+++ b/vmm/onedock/vmmfnc.sh
@@ -160,9 +160,11 @@ function setup_cd {
     CLEANUP_FILE=$3
     BOOTSTRAP_FILE=$4
 
-    if [ "$ONEDOCK_PRIVILEGED" != "True" -a "$ONEDOCK_SKIP_PRIVILEGED" == "True" ]; then
-        log_onedock_debug "Skipping mounting $TARGET because cannot create privileged\
-            containers and I am commited to avoid using it (ONEDOCK_SKIP_PRIVILEGED)"
+    if [ "$ONEDOCK_PRIVILEGED" != "True" \
+        -a "$ONEDOCK_SKIP_PRIVILEGED" == "True" ]; then
+        log_onedock_debug "Skipping mounting $TARGET because cannot create \
+            privileged containers and I am commited to avoid using it \
+            (ONEDOCK_SKIP_PRIVILEGED)"
         return 0
     fi
 
@@ -207,16 +209,7 @@ function setup_context {
     if [ "$DISK_ID" == "" ]; then
         return 0
     fi
-    # if [ "$DISK_ID" != "" ]; then
-    #    log_onedock_debug "setup_cd ${FOLDER}/disk.${DISK_ID} \
-    #        $TARGET $CLEANUP_FILE $BOOTSTRAP_FILE"
-    #    CONTEXT_STR=$(setup_cd "${FOLDER}/disk.${DISK_ID}" \
-    #        "$TARGET" "$CLEANUP_FILE" "$BOOTSTRAP_FILE")
-    #    if [ $? -ne 0 ]; then
-    #        return 1
-    #    fi
-    #fi
-    
+
     MOUNTFOLDER=${ONEDOCK_CONTAINER_FOLDER}/disk.${DISK_ID}.mountd
     ISOFILE=${FOLDER}/disk.${DISK_ID}
     ISOFILE=$(readlink -f $ISOFILE)


### PR DESCRIPTION
Fixing some bugs +
Changing the way that the context CD is handled. Now the context CD automatically appear in the /mnt folder (where vmcontext.sh would mount it). This approach avoids the need of the flag '--privileged' to be able to mount the contextualization CD.
